### PR TITLE
Fix lack of repository definition for integration test

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -48,6 +48,8 @@ repositories {
         mavenLocal()
     }
     mavenCentral()
+    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 


### PR DESCRIPTION
## Summary
This PR fixed lack of repository definition for integration test (#2).

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
Add repository definition to `integration/build.gradle`

## Related Issue, Pull Request or Code
#2
