### PR TITLE
Support `asakusafw.sh run` command.

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -20,6 +20,7 @@
     <module>hive</module>
     <module>windgate</module>
     <module>yaess</module>
+    <module>workflow</module>
 
     <module>batchspec</module>
     <module>inspection</module>

--- a/compiler/test-adapter/pom.xml
+++ b/compiler/test-adapter/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>asakusa-mapreduce-compiler-extension-yaess</artifactId>
+      <artifactId>asakusa-mapreduce-compiler-extension-workflow</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/compiler/workflow/.gitignore
+++ b/compiler/workflow/.gitignore
@@ -1,0 +1,4 @@
+/.settings
+/target
+/.classpath
+/.project

--- a/compiler/workflow/pom.xml
+++ b/compiler/workflow/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <name>Asakusa YAESS Description Generator Plug-in</name>
-  <artifactId>asakusa-mapreduce-compiler-extension-yaess</artifactId>
+  <name>Asakusa Workflow Information Generator Plug-in</name>
+  <artifactId>asakusa-mapreduce-compiler-extension-workflow</artifactId>
   <parent>
     <artifactId>project</artifactId>
     <groupId>com.asakusafw.mapreduce.compiler</groupId>
@@ -10,27 +10,10 @@
   </parent>
 
   <packaging>jar</packaging>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencies>
     <dependency>
-      <groupId>com.asakusafw</groupId>
-      <artifactId>asakusa-yaess-core</artifactId>
+      <groupId>com.asakusafw.workflow</groupId>
+      <artifactId>asakusa-workflow-model</artifactId>
       <version>${asakusafw.version}</version>
     </dependency>
     <dependency>
@@ -39,9 +22,20 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>${hadoop.artifact.id}</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-mapreduce-compiler-extension-yaess</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/compiler/workflow/src/main/java/com/asakusafw/compiler/workflow/Util.java
+++ b/compiler/workflow/src/main/java/com/asakusafw/compiler/workflow/Util.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.compiler.workflow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.asakusafw.compiler.flow.ExternalIoCommandProvider.CommandContext;
+import com.asakusafw.workflow.model.CommandToken;
+
+final class Util {
+
+    private static final String PH_HOME = "{{__PH__:HOME}}"; //$NON-NLS-1$
+
+    private static final String PH_EXECUTION_ID = "{{__PH__:EXECUTION_ID}}"; //$NON-NLS-1$
+
+    private static final String PH_BATCH_ARGUMENTS = "{{__PH__:BATCH_ARGUMENTS}}"; //$NON-NLS-1$
+
+    private Util() {
+        return;
+    }
+
+    public static CommandContext createMockCommandContext() {
+        return new CommandContext(PH_HOME, PH_EXECUTION_ID, PH_BATCH_ARGUMENTS);
+    }
+
+    public static String resolveCommand(String file) {
+        if (file.startsWith(PH_HOME) == false) {
+            return file;
+        }
+        return file.substring(PH_HOME.length());
+    }
+
+    public static List<CommandToken> resolveArguments(List<String> tokens) {
+        List<CommandToken> results = new ArrayList<>();
+        for (String token : tokens) {
+            if (isPlaceholder(token, PH_EXECUTION_ID)) {
+                results.add(CommandToken.EXECUTION_ID);
+            } else if (isPlaceholder(token, PH_BATCH_ARGUMENTS)) {
+                results.add(CommandToken.BATCH_ARGUMENTS);
+            } else if (isPlaceholder(token, PH_HOME)) {
+                throw new IllegalStateException(token);
+            } else {
+                results.add(CommandToken.of(token));
+            }
+        }
+        return results;
+    }
+
+    private static boolean isPlaceholder(String token, String placeholder) {
+        if (token.equals(placeholder)) {
+            return true;
+        }
+        if (token.indexOf(placeholder) >= 0) {
+            throw new IllegalStateException(token);
+        }
+        return false;
+    }
+}

--- a/compiler/workflow/src/main/java/com/asakusafw/compiler/workflow/WorkflowInformationProcessor.java
+++ b/compiler/workflow/src/main/java/com/asakusafw/compiler/workflow/WorkflowInformationProcessor.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.compiler.workflow;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.compiler.batch.AbstractWorkflowProcessor;
+import com.asakusafw.compiler.batch.WorkDescriptionProcessor;
+import com.asakusafw.compiler.batch.Workflow;
+import com.asakusafw.compiler.batch.WorkflowProcessor;
+import com.asakusafw.compiler.batch.processor.JobFlowWorkDescriptionProcessor;
+import com.asakusafw.compiler.flow.ExternalIoCommandProvider;
+import com.asakusafw.compiler.flow.ExternalIoCommandProvider.CommandContext;
+import com.asakusafw.compiler.flow.Location;
+import com.asakusafw.compiler.flow.jobflow.CompiledStage;
+import com.asakusafw.compiler.flow.jobflow.JobflowModel;
+import com.asakusafw.compiler.flow.jobflow.JobflowModel.Stage;
+import com.asakusafw.utils.graph.Graph;
+import com.asakusafw.utils.graph.Graphs;
+import com.asakusafw.vocabulary.batch.JobFlowWorkDescription;
+import com.asakusafw.workflow.model.DeleteTaskInfo;
+import com.asakusafw.workflow.model.JobflowInfo;
+import com.asakusafw.workflow.model.TaskInfo;
+import com.asakusafw.workflow.model.basic.BasicBatchInfo;
+import com.asakusafw.workflow.model.basic.BasicCommandTaskInfo;
+import com.asakusafw.workflow.model.basic.BasicDeleteTaskInfo;
+import com.asakusafw.workflow.model.basic.BasicHadoopTaskInfo;
+import com.asakusafw.workflow.model.basic.BasicJobflowInfo;
+import com.asakusafw.workflow.model.basic.BasicTaskInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * An implementation of {@link WorkflowProcessor} for workflow information.
+ * @since 0.10.0
+ */
+public class WorkflowInformationProcessor extends AbstractWorkflowProcessor {
+
+    static final Logger LOG = LoggerFactory.getLogger(WorkflowInformationProcessor.class);
+
+    private static final String DEFAULT_PROFILE_NAME = "default";
+
+    /**
+     * The script output path.
+     */
+    public static final String PATH = "etc/workflow.json"; //$NON-NLS-1$
+
+    @Override
+    public Collection<Class<? extends WorkDescriptionProcessor<?>>> getDescriptionProcessors() {
+        List<Class<? extends WorkDescriptionProcessor<?>>> results = new ArrayList<>();
+        results.add(JobFlowWorkDescriptionProcessor.class);
+        return results;
+    }
+
+    @Override
+    public void process(Workflow workflow) throws IOException {
+        LOG.debug("abalyzing workflow structure"); //$NON-NLS-1$
+        BasicBatchInfo info = toBatch(workflow);
+        write(info);
+    }
+
+    void write(BasicBatchInfo info) {
+        ObjectMapper mapper = new ObjectMapper();
+        try (OutputStream output = getEnvironment().openResource(PATH)) {
+            mapper.writerFor(com.asakusafw.workflow.model.BatchInfo.class).writeValue(output, info);
+        } catch (IOException | RuntimeException e) {
+            LOG.warn(MessageFormat.format(
+                            "error occurred while writing workflow information: {0}",
+                            PATH), e);
+        }
+    }
+
+    private BasicBatchInfo toBatch(Workflow info) {
+        Map<String, BasicJobflowInfo> elements = new LinkedHashMap<>();
+        String batchId = getEnvironment().getConfiguration().getBatchId();
+        for (Workflow.Unit unit : Graphs.sortPostOrder(info.getGraph())) {
+            BasicJobflowInfo jobflow = toJobflow(toJobflowModel(unit));
+            elements.put(jobflow.getId(), jobflow);
+        }
+        assert batchId != null;
+        for (Graph.Vertex<Workflow.Unit> vertex : info.getGraph()) {
+            BasicJobflowInfo jobflow = elements.get(vertex.getNode().getDescription().getName());
+            assert jobflow != null;
+            for (Workflow.Unit connected : vertex.getConnected()) {
+                BasicJobflowInfo blocker = elements.get(connected.getDescription().getName());
+                assert blocker != null;
+                jobflow.addBlocker(blocker);
+            }
+        }
+        BasicBatchInfo batch = new BasicBatchInfo(batchId);
+        for (JobflowInfo jobflow : elements.values()) {
+            batch.addElement(jobflow);
+        }
+        return batch;
+    }
+
+    private BasicJobflowInfo toJobflow(JobflowModel model) {
+        BasicJobflowInfo result = new BasicJobflowInfo(model.getFlowId());
+        processStages(result, TaskInfo.Phase.PROLOGUE, model.getCompiled().getPrologueStages());
+        processMain(model, result);
+        processStages(result, TaskInfo.Phase.EPILOGUE, model.getCompiled().getEpilogueStages());
+        processCleanup(result);
+        CommandContext context = Util.createMockCommandContext();
+        for (ExternalIoCommandProvider provider : model.getCompiled().getCommandProviders()) {
+            processPhase(result, TaskInfo.Phase.INITIALIZE, provider.getInitializeCommand(context));
+            processPhase(result, TaskInfo.Phase.IMPORT, provider.getImportCommand(context));
+            processPhase(result, TaskInfo.Phase.EXPORT, provider.getExportCommand(context));
+            processPhase(result, TaskInfo.Phase.FINALIZE, provider.getFinalizeCommand(context));
+        }
+        return result;
+    }
+
+    private static void processPhase(
+            BasicJobflowInfo result,
+            TaskInfo.Phase phase, List<ExternalIoCommandProvider.Command> commands) {
+        TaskInfo last = null;
+        for (ExternalIoCommandProvider.Command command : commands) {
+            LinkedList<String> tokens = new LinkedList<>(command.getCommandTokens());
+            String file = tokens.removeFirst();
+            BasicCommandTaskInfo task = new BasicCommandTaskInfo(
+                    command.getModuleName(),
+                    Optional.ofNullable(command.getProfileName())
+                            .orElse(DEFAULT_PROFILE_NAME),
+                    Util.resolveCommand(file),
+                    Util.resolveArguments(tokens));
+            if (last != null) {
+                task.addBlocker(last);
+            }
+            result.addTask(phase, task);
+            last = task;
+        }
+    }
+
+    private static void processStages(
+            BasicJobflowInfo result,
+            TaskInfo.Phase phase, List<CompiledStage> stages) {
+        stages.forEach(it -> result.addTask(phase, toTask(it)));
+    }
+
+    private static void processMain(JobflowModel model, BasicJobflowInfo result) {
+        Graph<Stage> graph = model.getDependencyGraph();
+        Map<Stage, BasicTaskInfo> tasks = new LinkedHashMap<>();
+        for (Stage stage : Graphs.sortPostOrder(graph)) {
+            BasicTaskInfo info = toTask(stage.getCompiled());
+            result.addTask(TaskInfo.Phase.MAIN, info);
+            tasks.put(stage, info);
+        }
+        tasks.forEach((stage, task) -> graph.getConnected(stage).stream()
+                .map(tasks::get)
+                .forEach(task::addBlocker));
+    }
+
+    private static BasicTaskInfo toTask(CompiledStage stage) {
+        return new BasicHadoopTaskInfo(stage.getQualifiedName().toNameString());
+    }
+
+    private void processCleanup(BasicJobflowInfo result) {
+        Location workingDirectory = getEnvironment().getConfiguration().getRootLocation();
+        result.addTask(TaskInfo.Phase.CLEANUP, new BasicDeleteTaskInfo(
+                DeleteTaskInfo.PathKind.HADOOP_FILE_SYSTEM,
+                workingDirectory.toPath('/')));
+    }
+
+    private static JobflowModel toJobflowModel(Workflow.Unit unit) {
+        assert unit != null;
+        assert unit.getDescription() instanceof JobFlowWorkDescription;
+        return (JobflowModel) unit.getProcessed();
+    }
+}

--- a/compiler/workflow/src/main/java/com/asakusafw/compiler/workflow/package-info.java
+++ b/compiler/workflow/src/main/java/com/asakusafw/compiler/workflow/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa DSL compiler extensions for workflow.
+ */
+package com.asakusafw.compiler.workflow;

--- a/compiler/workflow/src/main/resources/META-INF/services/com.asakusafw.compiler.batch.WorkflowProcessor
+++ b/compiler/workflow/src/main/resources/META-INF/services/com.asakusafw.compiler.batch.WorkflowProcessor
@@ -1,0 +1,1 @@
+com.asakusafw.compiler.workflow.WorkflowInformationProcessor

--- a/compiler/workflow/src/test/java/com/asakusafw/compiler/workflow/WorkflowInformationProcessorTest.java
+++ b/compiler/workflow/src/test/java/com/asakusafw/compiler/workflow/WorkflowInformationProcessorTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.compiler.workflow;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.compiler.flow.FlowCompilerOptions;
+import com.asakusafw.compiler.flow.Location;
+import com.asakusafw.compiler.testing.DirectBatchCompiler;
+import com.asakusafw.compiler.yaess.testing.batch.ComplexBatch;
+import com.asakusafw.compiler.yaess.testing.batch.DiamondBatch;
+import com.asakusafw.compiler.yaess.testing.batch.SimpleBatch;
+import com.asakusafw.vocabulary.batch.BatchDescription;
+import com.asakusafw.workflow.model.BatchInfo;
+import com.asakusafw.workflow.model.CommandTaskInfo;
+import com.asakusafw.workflow.model.HadoopTaskInfo;
+import com.asakusafw.workflow.model.JobflowInfo;
+import com.asakusafw.workflow.model.TaskInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Test for {@link WorkflowInformationProcessor}.
+ * @since 0.10.0
+ */
+public class WorkflowInformationProcessorTest {
+
+    /**
+     * Temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        BatchInfo info = compile(SimpleBatch.class);
+
+        assertThat(info.getId(), is("simple"));
+        assertThat(info.getElements(), hasSize(1));
+
+        JobflowInfo f0 = info.findElement("first").get();
+
+        assertThat(f0.getTasks(TaskInfo.Phase.INITIALIZE), hasCommands("initialize"));
+        assertThat(f0.getTasks(TaskInfo.Phase.IMPORT), hasCommands("import"));
+        assertThat(f0.getTasks(TaskInfo.Phase.PROLOGUE).size(), is(1));
+        assertThat(f0.getTasks(TaskInfo.Phase.MAIN).size(), is(1));
+        assertThat(f0.getTasks(TaskInfo.Phase.EPILOGUE).size(), is(1));
+        assertThat(f0.getTasks(TaskInfo.Phase.EXPORT), hasCommands("export"));
+        assertThat(f0.getTasks(TaskInfo.Phase.FINALIZE), hasCommands("finalize"));
+        assertThat(f0.getTasks(TaskInfo.Phase.CLEANUP).size(), is(1));
+    }
+
+    /**
+     * w/ multiple stages.
+     */
+    @Test
+    public void stages() {
+        BatchInfo info = compile(ComplexBatch.class);
+
+        assertThat(info.getId(), is("complex"));
+        assertThat(info.getElements(), hasSize(1));
+
+        JobflowInfo f0 = info.findElement("last").get();
+        Collection<? extends TaskInfo> main = f0.getTasks(TaskInfo.Phase.MAIN);
+        assertThat(main, hasSize(3));
+
+        TaskInfo s0 = main.stream()
+            .filter(it -> it.getBlockers().isEmpty())
+            .findFirst()
+            .get();
+
+        TaskInfo s1 = main.stream()
+                .filter(it -> it.getBlockers().contains(s0))
+                .findFirst()
+                .get();
+
+        TaskInfo s2 = main.stream()
+                .filter(it -> it.getBlockers().contains(s1))
+                .findFirst()
+                .get();
+
+        assertThat(s0, is(instanceOf(HadoopTaskInfo.class)));
+        assertThat(s1, is(instanceOf(HadoopTaskInfo.class)));
+        assertThat(s2, is(instanceOf(HadoopTaskInfo.class)));
+    }
+
+    /**
+     * w/ multiple flow.
+     */
+    @Test
+    public void flows() {
+        BatchInfo info = compile(DiamondBatch.class);
+
+        assertThat(info.getId(), is("diamond"));
+        assertThat(info.getElements(), hasSize(4));
+
+        JobflowInfo f0 = info.findElement("first").get();
+        JobflowInfo f1 = info.findElement("left").get();
+        JobflowInfo f2 = info.findElement("right").get();
+        JobflowInfo f3 = info.findElement("last").get();
+
+        assertThat(f0.getBlockers(), hasSize(0));
+        assertThat(f1.getBlockers(), containsInAnyOrder(f0));
+        assertThat(f2.getBlockers(), containsInAnyOrder(f0));
+        assertThat(f3.getBlockers(), containsInAnyOrder(f1, f2));
+    }
+
+    private BatchInfo compile(Class<? extends BatchDescription> batchClass) {
+        try {
+            File output = folder.newFolder("output");
+            DirectBatchCompiler.compile(
+                    batchClass,
+                    "com.example",
+                    Location.fromPath("testing", '/'),
+                    output,
+                    folder.newFolder("working"),
+                    Collections.emptyList(),
+                    getClass().getClassLoader(),
+                    new FlowCompilerOptions());
+            File script = new File(output, WorkflowInformationProcessor.PATH);
+            return new ObjectMapper().readValue(script, BatchInfo.class);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private Matcher<Collection<? extends TaskInfo>> hasCommands(String... executables) {
+        return new BaseMatcher<Collection<? extends TaskInfo>>() {
+            @Override
+            public boolean matches(Object target) {
+                if ((target instanceof Collection<?>) == false) {
+                    return false;
+                }
+                Collection<?> tasks = (Collection<?>) target;
+                List<String> commands = tasks.stream()
+                    .filter(it -> it instanceof CommandTaskInfo)
+                    .map(it -> (CommandTaskInfo) it)
+                    .map(it -> it.getCommand())
+                    .sorted()
+                    .collect(Collectors.toList());
+                if (tasks.size() != commands.size()) {
+                    return false;
+                }
+                return commands.equals(Arrays.stream(executables)
+                        .sorted()
+                        .collect(Collectors.toList()));
+            }
+            @Override
+            public void describeTo(Description desc) {
+                desc.appendText("executables of ");
+                desc.appendValue(Arrays.toString(executables));
+            }
+        };
+    }
+}

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
@@ -76,8 +76,11 @@ class AsakusaMapReduceSdkBasePlugin implements Plugin<Project> {
                 if (features.core) {
                     asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-core:${base.featureVersion}"
                     asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-inspection:${base.featureVersion}"
-                    asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-yaess:${base.featureVersion}"
+                    asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-workflow:${base.featureVersion}"
                     asakusaMapreduceCompiler "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-cli:${base.featureVersion}"
+                    if (features.yaess) {
+                        asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-yaess:${base.featureVersion}"
+                    }
                     if (features.directio) {
                         asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-directio:${base.featureVersion}"
                     }

--- a/integration/src/integration-test/data/mapreduce/build.gradle
+++ b/integration/src/integration-test/data/mapreduce/build.gradle
@@ -54,3 +54,15 @@ test {
         exceptionFormat 'full'
     }
 }
+
+task runTest(type: com.asakusafw.gradle.tasks.TestToolTask) {
+    batchArguments += [input : 'input']
+    batchArguments += [output : 'output']
+    clean description: 'com.example.KsvSortBatch'
+    prepare importer: 'com.example.KsvInputDescription',
+        data: '/com/example/simple.xls#data'
+    run batch: 'perf.average.sort'
+    verify exporter: 'com.example.KsvOutputDescription',
+        data: '/com/example/simple.xls#data',
+        rule: '/com/example/simple.xls#rule'
+}


### PR DESCRIPTION
## Summary

This PR supports `asakusafw.sh run` to execute Asakusa on Mapreduce applications.

## Background, Problem or Goal of the patch

See #9, asakusafw/asakusafw#747.

## Design of the fix, or a new feature

This introduced a new DSL compiler module that generate `etc/workflow.json`.
Note that `asakusafw.sh {list,draw}` are not supported for Asakusa on Mapreduce applications.

## Related Issue, Pull Request or Code

* #9
* asakusafw/asakusafw#747
