### PR TITLE
Promote Asakusa Vanilla as the default testkit.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceTestkit.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceTestkit.groovy
@@ -32,7 +32,7 @@ class AsakusaMapReduceTestkit implements AsakusaTestkit {
 
     @Override
     int getPriority() {
-        return 100
+        return 1
     }
 
     @Override


### PR DESCRIPTION
## Summary

This PR makes Asakusa Vanilla as the default testkit. The Vanilla testkit will be always enabled even if `asakusafw.sdk.incubating false` instead of Asakusa on MapReduce. 

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

This decrease `AsakusaMapReduceTestkit.priority` `{100=>1}`.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#144
