### PR TITLE
`asakusa run` on Windows.

### DIFF
--- a/compiler/windgate/src/main/java/com/asakusafw/compiler/windgate/WindGateIoProcessor.java
+++ b/compiler/windgate/src/main/java/com/asakusafw/compiler/windgate/WindGateIoProcessor.java
@@ -70,9 +70,9 @@ public class WindGateIoProcessor extends ExternalIoDescriptionProcessor {
      */
     public static final String MODULE_NAME = Constants.MODULE_NAME;
 
-    private static final String CMD_PROCESS = "windgate/bin/process.sh"; //$NON-NLS-1$
+    private static final String CMD_PROCESS = "windgate/bin/process"; //$NON-NLS-1$
 
-    private static final String CMD_FINALIZE = "windgate/bin/finalize.sh"; //$NON-NLS-1$
+    private static final String CMD_FINALIZE = "windgate/bin/finalize"; //$NON-NLS-1$
 
     private static final String OPT_IMPORT = "import"; //$NON-NLS-1$
 


### PR DESCRIPTION
## Summary

This PR enables `asakusa run` command to execute batch applications on Windows platform.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw#752.

## Design of the fix, or a new feature

Asakusa on MapReduce jobs has been already available on Windows since asakusafw/asakusafw#752, and this PR fixes upstream change which renames WindGate commands.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#752
