### PR TITLE
Enable limited `batch-info.json`.

### DIFF
--- a/compiler/info/.gitignore
+++ b/compiler/info/.gitignore
@@ -1,0 +1,4 @@
+/.settings
+/target
+/.classpath
+/.project

--- a/compiler/info/pom.xml
+++ b/compiler/info/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>Asakusa DSL Information Generator Plug-in</name>
+  <artifactId>asakusa-mapreduce-compiler-extension-info</artifactId>
+  <parent>
+    <artifactId>project</artifactId>
+    <groupId>com.asakusafw.mapreduce.compiler</groupId>
+    <version>0.10.0-SNAPSHOT</version>
+  </parent>
+
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.asakusafw.info</groupId>
+      <artifactId>asakusa-info-model</artifactId>
+      <version>${asakusafw.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-mapreduce-compiler-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>${hadoop.artifact.id}</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-mapreduce-compiler-extension-yaess</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/compiler/info/src/main/java/com/asakusafw/compiler/info/DslInformationProcessor.java
+++ b/compiler/info/src/main/java/com/asakusafw/compiler/info/DslInformationProcessor.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.compiler.info;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.compiler.batch.AbstractWorkflowProcessor;
+import com.asakusafw.compiler.batch.WorkDescriptionProcessor;
+import com.asakusafw.compiler.batch.Workflow;
+import com.asakusafw.compiler.batch.Workflow.Unit;
+import com.asakusafw.compiler.batch.WorkflowProcessor;
+import com.asakusafw.compiler.batch.processor.JobFlowWorkDescriptionProcessor;
+import com.asakusafw.compiler.flow.ExternalIoCommandProvider;
+import com.asakusafw.compiler.flow.ExternalIoCommandProvider.Command;
+import com.asakusafw.compiler.flow.ExternalIoCommandProvider.CommandContext;
+import com.asakusafw.compiler.flow.jobflow.CompiledStage;
+import com.asakusafw.compiler.flow.jobflow.JobflowModel;
+import com.asakusafw.compiler.flow.jobflow.JobflowModel.Stage;
+import com.asakusafw.info.BatchInfo;
+import com.asakusafw.info.JobflowInfo;
+import com.asakusafw.info.ParameterInfo;
+import com.asakusafw.info.ParameterListAttribute;
+import com.asakusafw.info.task.TaskInfo;
+import com.asakusafw.info.task.TaskListAttribute;
+import com.asakusafw.utils.graph.Graph;
+import com.asakusafw.utils.graph.Graphs;
+import com.asakusafw.vocabulary.batch.Batch;
+import com.asakusafw.vocabulary.batch.BatchDescription;
+import com.asakusafw.vocabulary.batch.JobFlowWorkDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * An implementation of {@link WorkflowProcessor} for DSL information.
+ * @since 0.10.0
+ */
+public class DslInformationProcessor extends AbstractWorkflowProcessor {
+
+    static final Logger LOG = LoggerFactory.getLogger(DslInformationProcessor.class);
+
+    private static final String HADOOP_MODULE_NAME = "hadoop";
+
+    private static final String DEFAULT_PROFILE_NAME = "default";
+
+    /**
+     * The script output path.
+     */
+    public static final String PATH = "etc/batch-info.json"; //$NON-NLS-1$
+
+    @Override
+    public Collection<Class<? extends WorkDescriptionProcessor<?>>> getDescriptionProcessors() {
+        List<Class<? extends WorkDescriptionProcessor<?>>> results = new ArrayList<>();
+        results.add(JobFlowWorkDescriptionProcessor.class);
+        return results;
+    }
+
+    @Override
+    public void process(Workflow workflow) throws IOException {
+        BatchInfo info = toBatch(workflow);
+        write(info);
+    }
+
+    void write(BatchInfo info) {
+        ObjectMapper mapper = new ObjectMapper();
+        try (OutputStream output = getEnvironment().openResource(PATH)) {
+            mapper.writerFor(BatchInfo.class).writeValue(output, info);
+        } catch (IOException | RuntimeException e) {
+            LOG.warn(MessageFormat.format(
+                    "error occurred while writing DSL information: {0}",
+                    PATH), e);
+        }
+    }
+
+    private BatchInfo toBatch(Workflow info) {
+        Graph<Unit> graph = info.getGraph();
+        Class<? extends BatchDescription> desc = info.getDescription().getClass();
+        Batch annotation = desc.getAnnotation(Batch.class);
+        BatchInfo batch = new BatchInfo(
+                getEnvironment().getConfiguration().getBatchId(),
+                desc.getName(),
+                Optional.ofNullable(annotation)
+                        .map(Batch::comment)
+                        .filter(it -> it.isEmpty() == false)
+                        .orElse(null),
+                Graphs.sortPostOrder(graph).stream()
+                        .map(unit -> toJobflow(graph, unit))
+                        .collect(Collectors.toList()),
+                Collections.singleton(Optional.ofNullable(annotation)
+                        .map(it -> collectParameters(it))
+                        .orElseGet(() -> new ParameterListAttribute(Collections.emptyList(), false))));
+        return batch;
+    }
+
+    private static JobflowInfo toJobflow(Graph<Workflow.Unit> graph, Workflow.Unit unit) {
+        return new JobflowInfo(
+                unit.getDescription().getName(),
+                unit.getDescription().getClass().getName(),
+                graph.getConnected(unit).stream()
+                        .map(it -> it.getDescription().getName())
+                        .sorted()
+                        .collect(Collectors.toList()),
+                Collections.singletonList(collectTasks(unit)));
+    }
+
+    private static TaskListAttribute collectTasks(Workflow.Unit unit) {
+        JobflowModel model = toJobflowModel(unit);
+        CommandContext context = new CommandContext("A", "E", Collections.emptyMap());
+        List<TaskInfo> results = new ArrayList<>();
+        for (ExternalIoCommandProvider provider : model.getCompiled().getCommandProviders()) {
+            results.addAll(collectPhase(TaskInfo.Phase.INITIALIZE, provider.getInitializeCommand(context)));
+            results.addAll(collectPhase(TaskInfo.Phase.IMPORT, provider.getImportCommand(context)));
+        }
+        results.addAll(collectStages(TaskInfo.Phase.PROLOGUE, model.getCompiled().getPrologueStages()));
+        results.addAll(collectMain(model));
+        results.addAll(collectStages(TaskInfo.Phase.EPILOGUE, model.getCompiled().getEpilogueStages()));
+        for (ExternalIoCommandProvider provider : model.getCompiled().getCommandProviders()) {
+            results.addAll(collectPhase(TaskInfo.Phase.EXPORT, provider.getExportCommand(context)));
+            results.addAll(collectPhase(TaskInfo.Phase.FINALIZE, provider.getFinalizeCommand(context)));
+        }
+        return new TaskListAttribute(results);
+    }
+
+    private static List<TaskInfo> collectMain(JobflowModel model) {
+        Graph<Stage> graph = model.getDependencyGraph();
+        return graph.getNodeSet().stream()
+                .sorted(Comparator.comparingInt(Stage::getNumber))
+                .map(stage -> new TaskInfo(
+                    stage.getCompiled().getStageId(),
+                    TaskInfo.Phase.MAIN,
+                    HADOOP_MODULE_NAME,
+                    DEFAULT_PROFILE_NAME,
+                    graph.getConnected(stage).stream()
+                            .sorted(Comparator.comparingInt(Stage::getNumber))
+                            .map(blocker -> blocker.getCompiled().getStageId())
+                            .collect(Collectors.toList())))
+                .collect(Collectors.toList());
+    }
+
+    private static List<TaskInfo> collectStages(TaskInfo.Phase phase, List<CompiledStage> stages) {
+        return stages.stream()
+                .map(it -> new TaskInfo(
+                        it.getStageId(),
+                        phase,
+                        HADOOP_MODULE_NAME,
+                        DEFAULT_PROFILE_NAME,
+                        Collections.emptyList()))
+                .collect(Collectors.toList());
+    }
+
+    private static List<TaskInfo> collectPhase(TaskInfo.Phase phase, List<Command> commands) {
+        List<TaskInfo> results = new ArrayList<>();
+        for (ExternalIoCommandProvider.Command command : commands) {
+            results.add(new TaskInfo(
+                    String.valueOf(results.size()),
+                    phase,
+                    command.getModuleName(),
+                    Optional.ofNullable(command.getProfileName())
+                            .orElse(DEFAULT_PROFILE_NAME),
+                    Collections.emptyList()));
+        }
+        return results;
+    }
+
+    private static ParameterListAttribute collectParameters(Batch batch) {
+        return new ParameterListAttribute(
+                Arrays.stream(batch.parameters())
+                        .map(it -> new ParameterInfo(
+                                it.key(),
+                                Optional.of(it.comment())
+                                        .filter(s -> s.isEmpty() == false)
+                                        .orElse(null),
+                                it.required(),
+                                Optional.of(it.pattern())
+                                        .filter(Predicate.isEqual(Batch.DEFAULT_PARAMETER_VALUE_PATTERN).negate())
+                                        .orElse(null)))
+                        .collect(Collectors.toList()),
+                batch.strict());
+    }
+
+    private static JobflowModel toJobflowModel(Workflow.Unit unit) {
+        assert unit != null;
+        assert unit.getDescription() instanceof JobFlowWorkDescription;
+        return (JobflowModel) unit.getProcessed();
+    }
+}

--- a/compiler/info/src/main/java/com/asakusafw/compiler/info/package-info.java
+++ b/compiler/info/src/main/java/com/asakusafw/compiler/info/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa DSL compiler extensions for information viewer.
+ */
+package com.asakusafw.compiler.info;

--- a/compiler/info/src/main/resources/META-INF/services/com.asakusafw.compiler.batch.WorkflowProcessor
+++ b/compiler/info/src/main/resources/META-INF/services/com.asakusafw.compiler.batch.WorkflowProcessor
@@ -1,0 +1,1 @@
+com.asakusafw.compiler.info.DslInformationProcessor

--- a/compiler/info/src/test/java/com/asakusafw/compiler/info/DslInformationProcessorTest.java
+++ b/compiler/info/src/test/java/com/asakusafw/compiler/info/DslInformationProcessorTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.compiler.info;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.compiler.flow.FlowCompilerOptions;
+import com.asakusafw.compiler.flow.Location;
+import com.asakusafw.compiler.testing.DirectBatchCompiler;
+import com.asakusafw.compiler.yaess.testing.batch.ComplexBatch;
+import com.asakusafw.compiler.yaess.testing.batch.DiamondBatch;
+import com.asakusafw.compiler.yaess.testing.batch.SimpleBatch;
+import com.asakusafw.info.BatchInfo;
+import com.asakusafw.info.JobflowInfo;
+import com.asakusafw.info.task.TaskInfo;
+import com.asakusafw.info.task.TaskListAttribute;
+import com.asakusafw.vocabulary.batch.BatchDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Test for {@link DslInformationProcessor}.
+ */
+public class DslInformationProcessorTest {
+
+    /**
+     * Temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        BatchInfo info = compile(SimpleBatch.class);
+
+        assertThat(info.getId(), is("simple"));
+        assertThat(info.getJobflows(), hasSize(1));
+
+        JobflowInfo f0 = jobflow(info, "first");
+        assertThat(f0.getBlockerIds(), hasSize(0));
+
+        assertThat(tasks(f0, TaskInfo.Phase.INITIALIZE), hasSize(1));
+        assertThat(tasks(f0, TaskInfo.Phase.IMPORT), hasSize(1));
+        assertThat(tasks(f0, TaskInfo.Phase.PROLOGUE), hasSize(1));
+        assertThat(tasks(f0, TaskInfo.Phase.MAIN), hasSize(1));
+        assertThat(tasks(f0, TaskInfo.Phase.EPILOGUE), hasSize(1));
+        assertThat(tasks(f0, TaskInfo.Phase.EXPORT), hasSize(1));
+        assertThat(tasks(f0, TaskInfo.Phase.FINALIZE), hasSize(1));
+    }
+
+    /**
+     * w/ multiple stages.
+     */
+    @Test
+    public void stages() {
+        BatchInfo info = compile(ComplexBatch.class);
+
+        assertThat(info.getId(), is("complex"));
+        assertThat(info.getJobflows(), hasSize(1));
+
+        JobflowInfo f0 = jobflow(info, "last");
+        List<TaskInfo> main = tasks(f0, TaskInfo.Phase.MAIN);
+
+        assertThat(main, hasSize(3));
+
+        TaskInfo s0 = main.stream()
+            .filter(it -> it.getBlockers().isEmpty())
+            .findFirst()
+            .get();
+
+        TaskInfo s1 = main.stream()
+                .filter(it -> it.getBlockers().contains(s0.getId()))
+                .findFirst()
+                .get();
+
+        main.stream()
+                .filter(it -> it.getBlockers().contains(s1.getId()))
+                .findFirst()
+                .get();
+    }
+
+    /**
+     * w/ multiple flow.
+     */
+    @Test
+    public void flows() {
+        BatchInfo info = compile(DiamondBatch.class);
+
+        assertThat(info.getId(), is("diamond"));
+        assertThat(info.getJobflows(), hasSize(4));
+
+        JobflowInfo f0 = jobflow(info, "first");
+        JobflowInfo f1 = jobflow(info, "left");
+        JobflowInfo f2 = jobflow(info, "right");
+        JobflowInfo f3 = jobflow(info, "last");
+
+        assertThat(f0.getBlockerIds(), hasSize(0));
+        assertThat(f1.getBlockerIds(), containsInAnyOrder(f0.getId()));
+        assertThat(f2.getBlockerIds(), containsInAnyOrder(f0.getId()));
+        assertThat(f3.getBlockerIds(), containsInAnyOrder(f1.getId(), f2.getId()));
+    }
+
+    private static JobflowInfo jobflow(BatchInfo parent, String id) {
+        return parent.getJobflows().stream()
+                .filter(it -> it.getId().equals(id))
+                .findFirst()
+                .get();
+    }
+
+    private List<TaskInfo> tasks(JobflowInfo jobflow, TaskInfo.Phase phase) {
+        return jobflow.findAttribute(TaskListAttribute.class)
+                .map(it -> it.getPhases().getOrDefault(phase, Collections.emptyList()))
+                .orElse(Collections.emptyList());
+    }
+
+    private BatchInfo compile(Class<? extends BatchDescription> batchClass) {
+        try {
+            File output = folder.newFolder("output");
+            DirectBatchCompiler.compile(
+                    batchClass,
+                    "com.example",
+                    Location.fromPath("testing", '/'),
+                    output,
+                    folder.newFolder("working"),
+                    Collections.emptyList(),
+                    getClass().getClassLoader(),
+                    new FlowCompilerOptions());
+            File script = new File(output, DslInformationProcessor.PATH);
+            return new ObjectMapper().readValue(script, BatchInfo.class);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+}

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -20,6 +20,7 @@
     <module>hive</module>
     <module>windgate</module>
     <module>yaess</module>
+    <module>info</module>
     <module>workflow</module>
 
     <module>batchspec</module>

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
@@ -76,6 +76,7 @@ class AsakusaMapReduceSdkBasePlugin implements Plugin<Project> {
                 if (features.core) {
                     asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-core:${base.featureVersion}"
                     asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-inspection:${base.featureVersion}"
+                    asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-info:${base.featureVersion}"
                     asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-workflow:${base.featureVersion}"
                     asakusaMapreduceCompiler "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-cli:${base.featureVersion}"
                     if (features.yaess) {

--- a/integration/src/integration-test/java/com/asakusafw/integration/mapreduce/PortalTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/mapreduce/PortalTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.integration.mapreduce;
+
+import static com.asakusafw.integration.mapreduce.Util.*;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.asakusafw.integration.AsakusaConfigurator;
+import com.asakusafw.integration.AsakusaConstants;
+import com.asakusafw.integration.AsakusaProjectProvider;
+import com.asakusafw.utils.gradle.Bundle;
+import com.asakusafw.utils.gradle.ContentsConfigurator;
+
+/**
+ * Test for the portal command.
+ */
+public class PortalTest {
+
+    /**
+     * project provider.
+     */
+    @ClassRule
+    public static final AsakusaProjectProvider PROVIDER = new AsakusaProjectProvider()
+            .withProject(ContentsConfigurator.copy(data("mapreduce")))
+            .withProject(ContentsConfigurator.copy(data("ksv")))
+            .withProject(ContentsConfigurator.copy(data("logback-test")))
+            .withProject(AsakusaConfigurator.projectHome())
+            .withProvider(provider -> {
+                // install framework only once
+                framework = provider.newInstance("inf")
+                        .gradle("attachMapreduceBatchapps", "installAsakusafw")
+                        .getFramework();
+            });
+
+    static Bundle framework;
+
+    /**
+     * {@code list parameter}.
+     */
+    @Test
+    public void list_parameter() {
+        framework.withLaunch(AsakusaConstants.CMD_PORTAL, "list", "parameter", "-v",
+                "perf.average.sort");
+    }
+
+    /**
+     * {@code list jobflow}.
+     */
+    @Test
+    public void list_jobflow() {
+        framework.withLaunch(AsakusaConstants.CMD_PORTAL, "list", "jobflow", "-v",
+                "perf.average.sort");
+    }
+
+    /**
+     * {@code draw jobflow}.
+     */
+    @Test
+    public void draw_jobflow() {
+        framework.withLaunch(AsakusaConstants.CMD_PORTAL, "draw", "jobflow", "-v",
+                "perf.average.sort");
+    }
+}


### PR DESCRIPTION
## Summary

`batch-info.json` is also now limited available for Asakusa on MapReduce.

It only includes following information:
* batch parameter (`asakusa list parameter`)
* jobflow graph (`asakusa {list,draw} jobflow`)
* task graph (`asakusa {list,draw} jobflow` with `-v`)

## Background, Problem or Goal of the patch

In the latest implementation, Asakusa on MapReduce DSL compiler does not produce `batch-info.json` file. If it does not exist, `asakusa list batch` simply ignore the target batch application. We think it is misleading as if there are no batch applications.

## Design of the fix, or a new feature

Task graph (`asakusa {list,draw} jobflow -v`) is currently optimized for Asakusa on Spark or M3BP (`main` phase only contains one task), so that `batch-info.json` for Asakusa on MapReduce DSL may not provide informative task graphs. Please also refer `$ASAKUSA_HOME/batchapps/<batch-id>/opt/dsl-analysis` instead.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#747
* asakusafw/asakusafw#750
