### PR TITLE
Add test of `asakusaUpgrade` with Gradle 4.1.

### DIFF
--- a/gradle/src/test/groovy/com/asakusafw/mapreduce/gradle/plugins/AsakusaUpgradeTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/mapreduce/gradle/plugins/AsakusaUpgradeTest.groovy
@@ -50,6 +50,14 @@ class AsakusaUpgradeTest {
     }
 
     /**
+     * Test for {@code 4.1} (Asakusa on MapReduce {@code 0.10.0}).
+     */
+    @Test
+    void 'v4.1'() {
+        doUpgradeFromTestName()
+    }
+
+    /**
      * Test for {@code 3.4.1} (Asakusa on MapReduce {@code 0.9.2}).
      */
     @Test


### PR DESCRIPTION
## Summary

This PR adds unit test for upstream change of Gradle version (asakusafw/asakusafw#759).

## Background, Problem or Goal of the patch

See asakusafw/asakusafw#759.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#759