### PR TITLE
Bump Gradle required Java version to 1.8.

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -58,8 +58,7 @@ dependencies {
     deployerJars 'org.springframework.build:aws-maven:5.0.0.RELEASE'
 }
 
-project.sourceCompatibility = JavaVersion.toVersion('1.7')
-project.targetCompatibility = JavaVersion.toVersion('1.7')
+project.sourceCompatibility = JavaVersion.toVersion('1.8')
 
 tasks.withType(AbstractCompile) { task ->
     task.options.encoding = 'UTF-8'


### PR DESCRIPTION
## Summary

This PR bumps Gradle required JDK version to `1.8`.

## Background, Problem or Goal of the patch

See asakusafw/asakusafw#760.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* See asakusafw/asakusafw#760.
