### PR TITLE
Migrate from FindBugs to SpotBugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <plugin.aws-maven.version>5.0.0.RELEASE</plugin.aws-maven.version>
     <plugin.license.version>3.0</plugin.license.version>
     <plugin.checkstyle.version>2.17</plugin.checkstyle.version>
-    <plugin.findbugs.version>3.0.5</plugin.findbugs.version>
+    <plugin.spotbugs.version>3.1.8</plugin.spotbugs.version>
     <plugin.site.version>3.6</plugin.site.version>
     <plugin.project-info-reports.version>2.9</plugin.project-info-reports.version>
     <plugin.surefire-report.version>2.20</plugin.surefire-report.version>
@@ -397,9 +397,9 @@ encoding/<project>=UTF-8
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>${plugin.findbugs.version}</version>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>${plugin.spotbugs.version}</version>
           <dependencies>
             <dependency>
               <groupId>com.asakusafw</groupId>
@@ -409,7 +409,6 @@ encoding/<project>=UTF-8
           </dependencies>
           <configuration>
             <xmlOutput>true</xmlOutput>
-            <findbugsXmlOutput>true</findbugsXmlOutput>
             <sourceEncoding>UTF-8</sourceEncoding>
             <outputEncoding>UTF-8</outputEncoding>
           </configuration>


### PR DESCRIPTION
## Summary
This PR migrates from findbugs to spotbugs.

## Background, Problem or Goal of the patch
Findbugs is no longer maintained and SpotBugs is carrying on it.

## Design of the fix, or a new feature
Modifies `pom.xml` to use latest spotbugs version.

## Related Issue, Pull Request or Code
N/A.